### PR TITLE
Fix SIGBUS errors during Next.js parallel builds

### DIFF
--- a/src/exporter/files.test.ts
+++ b/src/exporter/files.test.ts
@@ -1,4 +1,6 @@
 import fs from 'fs/promises'
+import fsSync from 'fs'
+import path from 'path'
 import { test } from 'uvu'
 import * as td from 'testdouble'
 import * as assert from 'uvu/assert'
@@ -386,5 +388,98 @@ for (const t of testsDecodeHtmlEntities) {
     assert.equal(result, expected)
   })
 }
+
+// --- Concurrency safety tests ---
+
+test('saveImage concurrent calls for same URL do not corrupt file', async () => {
+  const url = 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'
+  const concurrency = 5
+
+  const promises = Array.from({ length: concurrency }, () =>
+    files.saveImage(url, 'concurrent-test')
+  )
+  const results = await Promise.all(promises)
+
+  // All results should return the same path
+  const paths = results.map(r => r.path)
+  const uniquePaths = [...new Set(paths)]
+  assert.equal(uniquePaths.length, 1, `All concurrent calls should return same path, got: ${uniquePaths}`)
+
+  // All results should have valid dimensions
+  for (const r of results) {
+    assert.ok(r.width, 'width should be defined')
+    assert.ok(r.height, 'height should be defined')
+  }
+})
+
+test('saveFile concurrent calls for same URL do not corrupt file', async () => {
+  const url = 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'
+  const concurrency = 5
+
+  const promises = Array.from({ length: concurrency }, () =>
+    files.saveFile(url, 'concurrent-test')
+  )
+  const results = await Promise.all(promises)
+
+  // All results should return the same src path
+  const srcs = results.map(r => r.src)
+  const uniqueSrcs = [...new Set(srcs)]
+  assert.equal(uniqueSrcs.length, 1, `All concurrent calls should return same src, got: ${uniqueSrcs}`)
+
+  // All results should have consistent file size
+  const sizes = results.map(r => r.size)
+  const uniqueSizes = [...new Set(sizes)]
+  assert.equal(uniqueSizes.length, 1, `All concurrent calls should return same size, got: ${uniqueSizes}`)
+  assert.ok(sizes[0] > 0, 'file size should be > 0')
+})
+
+test('writeCache concurrent writes produce valid JSON', async () => {
+  const cacheFile = 'testdata/concurrent-cache-test.json'
+  const concurrency = 10
+
+  const promises = Array.from({ length: concurrency }, (_, i) =>
+    files.writeCache(cacheFile, { index: i, data: `value-${i}` })
+  )
+  await Promise.all(promises)
+
+  // The file should contain valid JSON (one of the writes should win)
+  const content = await fs.readFile(cacheFile, 'utf8')
+  let parsed: any
+  try {
+    parsed = JSON.parse(content)
+  } catch (e) {
+    assert.unreachable(`Cache file should contain valid JSON after concurrent writes, got: ${content}`)
+  }
+  assert.ok(typeof parsed.index === 'number', 'parsed result should have index')
+  assert.ok(typeof parsed.data === 'string', 'parsed result should have data')
+
+  // Clean up
+  await fs.unlink(cacheFile)
+})
+
+test('writeCache uses atomic rename (no partial writes visible)', async () => {
+  const cacheFile = 'testdata/atomic-cache-test.json'
+  const largeData = { key: 'x'.repeat(10000) }
+
+  await files.writeCache(cacheFile, largeData)
+
+  const content = await fs.readFile(cacheFile, 'utf8')
+  const parsed = JSON.parse(content)
+  assert.equal(parsed.key.length, 10000, 'full data should be written atomically')
+
+  // Clean up
+  await fs.unlink(cacheFile)
+})
+
+test('saveFile writeStream finish is awaited (file is complete on return)', async () => {
+  const url = 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'
+  const result = await files.saveFile(url, 'stream-finish-test')
+
+  // File should exist and be readable immediately after saveFile returns
+  const filePath = `public${result.src}`
+  const stats = await fs.stat(filePath)
+  assert.ok(stats.size > 0, 'file should have content')
+  assert.equal(stats.size, result.size, 'reported size should match actual file size')
+})
 
 test.run()

--- a/src/exporter/files.test.ts
+++ b/src/exporter/files.test.ts
@@ -1,6 +1,4 @@
 import fs from 'fs/promises'
-import fsSync from 'fs'
-import path from 'path'
 import { test } from 'uvu'
 import * as td from 'testdouble'
 import * as assert from 'uvu/assert'

--- a/src/exporter/files.ts
+++ b/src/exporter/files.ts
@@ -21,6 +21,7 @@ import {
   maxRedirects,
   isSkipDownload,
 } from './variables.js'
+import { withFileLock } from './mutex.js'
 import type {
   VideoBlockObjectResponseEx,
   EmbedBlockObjectResponseEx,
@@ -263,7 +264,13 @@ export async function readCache<T> (f: string): Promise<T> {
 }
 
 export async function writeCache (f: string, data: unknown): Promise<void> {
-  return writeFile(f, JSON.stringify(data), 'utf8').catch(() => {})
+  const tmp = `${f}.${process.pid}.tmp`
+  try {
+    await writeFile(tmp, JSON.stringify(data), 'utf8')
+    await fs.promises.rename(tmp, f)
+  } catch {
+    try { await fs.promises.unlink(tmp) } catch {}
+  }
 }
 
 export async function isAvailableCache (f: string, d?: number): Promise<boolean> {
@@ -284,45 +291,51 @@ export async function saveFile (fileUrl: string, prefix: string) {
   const urlPath = `/${fileDir}/${prefix}-${basename}`
   const filePath = `${docRoot}${urlPath}`
   const dirPath = `${docRoot}/${fileDir}`
+  const lockKey = `savefile-${atoh(filePath)}`
 
   await createDirWhenNotfound(dirPath)
 
-  if (fs.existsSync(filePath)) {
+  return withFileLock(lockKey, async () => {
+    if (fs.existsSync(filePath)) {
+      const stats = await stat(filePath)
+      return {
+        src: urlPath,
+        size: stats.size,
+      }
+
+    /* Download file */
+    } else {
+      try {
+        let res: HttpGetResponse
+        res = await httpsGetWithFollowRedirects(fileUrl)
+        if (res.statusCode >= 400 && res.statusCode < 500 && imageDir !== urlWithoutQuerystring) {
+          res = await httpsGetWithFollowRedirects(urlWithoutQuerystring)
+          if (res.statusCode >= 400 && res.statusCode < 500) {
+            throw new Error(`retry download to ${urlWithoutQuerystring} but failed`)
+          }
+        }
+        const writeStream = fs.createWriteStream(filePath)
+        res.pipe(writeStream)
+        await res.end
+        await new Promise<void>((resolve, reject) => {
+          writeStream.on('finish', resolve)
+          writeStream.on('error', reject)
+        })
+      } catch (e) {
+        const errorMessage = `saveFile download error -- path: ${filePath}, url: ${fileUrl}, message: ${e}`
+        if (debug) {
+          console.log(errorMessage)
+        }
+        throw new Error(errorMessage)
+      }
+    }
+
     const stats = await stat(filePath)
     return {
       src: urlPath,
       size: stats.size,
     }
-
-  /* Download file */
-  } else {
-    try {
-      let res: HttpGetResponse
-      res = await httpsGetWithFollowRedirects(fileUrl)
-      if (res.statusCode >= 400 && res.statusCode < 500 && imageDir !== urlWithoutQuerystring) {
-        res = await httpsGetWithFollowRedirects(urlWithoutQuerystring)
-        if (res.statusCode >= 400 && res.statusCode < 500) {
-          throw new Error(`retry download to ${urlWithoutQuerystring} but failed`)
-        }
-      }
-      res.pipe(fs.createWriteStream(filePath))
-      await res.end
-      // This fix that for fileType do not returns undefined
-      await sleep(10)
-    } catch (e) {
-      const errorMessage = `saveFile download error -- path: ${filePath}, url: ${fileUrl}, message: ${e}`
-      if (debug) {
-        console.log(errorMessage)
-      }
-      throw new Error(errorMessage)
-    }
-  }
-
-  const stats = await stat(filePath)
-  return {
-    src: urlPath,
-    size: stats.size,
-  }
+  })
 }
 
 export const saveImage = async (imageUrl: string, prefix: string): Promise<ImagePathWithSize> => {
@@ -334,130 +347,134 @@ export const saveImage = async (imageUrl: string, prefix: string): Promise<Image
   const dirPath = `${docRoot}/${imageDir}`
   const webpUrlPath = replaceExt(urlPath, '.webp')
   const webpPath = `${docRoot}${webpUrlPath}`
+  const lockKey = `saveimage-${atoh(filePath)}`
 
   await createDirWhenNotfound(dirPath)
 
-  if (fs.existsSync(filePath)) {
-    if (webpQuality > 0 && fs.existsSync(webpPath)) {
-      try {
-        const meta = await sharp(webpPath).metadata()
-        return {
-          path: webpUrlPath,
-          width: meta.width,
-          height: meta.height,
+  return withFileLock(lockKey, async () => {
+    if (fs.existsSync(filePath)) {
+      if (webpQuality > 0 && fs.existsSync(webpPath)) {
+        try {
+          const meta = await sharp(webpPath).metadata()
+          return {
+            path: webpUrlPath,
+            width: meta.width,
+            height: meta.height,
+          }
+        } catch(e) {
+          if (debug) {
+            console.log(`sharp.metadata() error -- path: ${webpUrlPath}, message: ${e}`)
+          }
+          return { path: webpUrlPath }
         }
-      } catch(e) {
-        if (debug) {
-          console.log(`sharp.metadata() error -- path: ${webpUrlPath}, message: ${e}`)
+      } else {
+        if (ext === '.ico' || ext === '.svg') {
+          return { path: urlPath }
         }
-        return { path: webpUrlPath }
+        try {
+          const meta = await sharp(filePath).metadata()
+          return {
+            path: urlPath,
+            width: meta.width,
+            height: meta.height,
+          }
+        } catch(e) {
+          if (debug) {
+            console.log(`sharp.metadata() error -- path: ${urlPath}, message: ${e}`)
+          }
+          return { path: urlPath }
+        }
       }
+
+    /* Download image */
     } else {
-      if (ext === '.ico' || ext === '.svg') {
+      if (isSkipDownload()) {
         return { path: urlPath }
       }
+
       try {
-        const meta = await sharp(filePath).metadata()
-        return {
-          path: urlPath,
-          width: meta.width,
-          height: meta.height,
+        let res: HttpGetResponse
+        res = await httpsGetWithFollowRedirects(imageUrl)
+        if (res.statusCode >= 400 && res.statusCode < 500 && imageDir !== urlWithoutQuerystring) {
+          res = await httpsGetWithFollowRedirects(urlWithoutQuerystring)
+          if (res.statusCode >= 400 && res.statusCode < 500) {
+            throw new Error(`retry download to ${urlWithoutQuerystring} but failed`)
+          }
         }
-      } catch(e) {
+        const writeStream = fs.createWriteStream(filePath)
+        res.pipe(writeStream)
+        await res.end
+        await new Promise<void>((resolve, reject) => {
+          writeStream.on('finish', resolve)
+          writeStream.on('error', reject)
+        })
+      } catch (e) {
+        const errorMessage = `saveImage download error -- path: ${filePath}, url: ${imageUrl}, message: ${e}`
         if (debug) {
-          console.log(`sharp.metadata() error -- path: ${urlPath}, message: ${e}`)
+          console.log(errorMessage)
         }
-        return { path: urlPath }
+        throw new Error(errorMessage)
       }
     }
 
-  /* Download image */
-  } else {
-    if (isSkipDownload()) {
+    if (ext === '.ico' || ext === '.svg') {
       return { path: urlPath }
     }
 
-    try {
-      let res: HttpGetResponse
-      res = await httpsGetWithFollowRedirects(imageUrl)
-      if (res.statusCode >= 400 && res.statusCode < 500 && imageDir !== urlWithoutQuerystring) {
-        res = await httpsGetWithFollowRedirects(urlWithoutQuerystring)
-        if (res.statusCode >= 400 && res.statusCode < 500) {
-          throw new Error(`retry download to ${urlWithoutQuerystring} but failed`)
+    /* Convert HEIC/HEIF to PNG first if needed */
+    let processFilePath = filePath
+    let processUrlPath = urlPath
+    if (ext === '.heic' || ext === '.heif') {
+      try {
+        if (debug) {
+          console.log(`Converting HEIC/HEIF to PNG -- path: ${filePath}`)
+        }
+        const heicBuffer = await readFile(filePath)
+        const pngArrayBuffer = await heicConvert({
+          buffer: heicBuffer.buffer.slice(heicBuffer.byteOffset, heicBuffer.byteOffset + heicBuffer.byteLength),
+          format: 'PNG',
+        })
+        const pngBuffer = Buffer.from(pngArrayBuffer)
+        const pngPath = replaceExt(filePath, '.png')
+        await writeFile(pngPath, pngBuffer)
+        await unlink(filePath)
+        processFilePath = pngPath
+        processUrlPath = replaceExt(urlPath, '.png')
+        if (debug) {
+          console.log(`Converted HEIC/HEIF to PNG -- from: ${filePath}, to: ${pngPath}`)
+        }
+      } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e)
+        if (debug) {
+          console.log(`HEIC/HEIF to PNG conversion error -- path: ${filePath}, message: ${errorMessage}`)
         }
       }
-      const writeStream = fs.createWriteStream(filePath)
-      res.pipe(writeStream)
-      await res.end
-      // Wait for the write stream to finish
-      await new Promise<void>((resolve, reject) => {
-        writeStream.on('finish', resolve)
-        writeStream.on('error', reject)
-      })
-    } catch (e) {
-      const errorMessage = `saveImage download error -- path: ${filePath}, url: ${imageUrl}, message: ${e}`
-      if (debug) {
-        console.log(errorMessage)
-      }
-      throw new Error(errorMessage)
     }
-  }
 
-  if (ext === '.ico' || ext === '.svg') {
-    return { path: urlPath }
-  }
-
-  /* Convert HEIC/HEIF to PNG first if needed */
-  let processFilePath = filePath
-  let processUrlPath = urlPath
-  if (ext === '.heic' || ext === '.heif') {
+    /* Convert to webp */
     try {
-      if (debug) {
-        console.log(`Converting HEIC/HEIF to PNG -- path: ${filePath}`)
-      }
-      const heicBuffer = await readFile(filePath)
-      const pngArrayBuffer = await heicConvert({
-        buffer: heicBuffer.buffer.slice(heicBuffer.byteOffset, heicBuffer.byteOffset + heicBuffer.byteLength),
-        format: 'PNG',
-      })
-      const pngBuffer = Buffer.from(pngArrayBuffer)
-      const pngPath = replaceExt(filePath, '.png')
-      await writeFile(pngPath, pngBuffer)
-      // Delete original HEIC file
-      await unlink(filePath)
-      processFilePath = pngPath
-      processUrlPath = replaceExt(urlPath, '.png')
-      if (debug) {
-        console.log(`Converted HEIC/HEIF to PNG -- from: ${filePath}, to: ${pngPath}`)
-      }
-    } catch (e) {
-      const errorMessage = e instanceof Error ? e.message : String(e)
-      if (debug) {
-        console.log(`HEIC/HEIF to PNG conversion error -- path: ${filePath}, message: ${errorMessage}`)
-      }
-      // Fall through to try WebP conversion with original file
-    }
-  }
-
-  /* Convert to webp */
-  try {
-    const meta = await sharp(processFilePath).metadata()
-    if (webpQuality > 0) {
-      // Convert various image formats to webp (png, jpeg, heic, heif, tiff, avif, etc.)
-      // Exclude gif to preserve animations
-      if (meta.format && meta.format !== 'gif') {
-        if (meta.orientation && [3,6,8].includes(meta.orientation)) {
-          const angle = (meta.orientation === 6) ? 90 : (meta.orientation === 8) ? -90 : 180
-          await sharp(processFilePath).rotate(angle).webp({ quality: webpQuality }).toFile(webpPath)
-          return {
-            path: webpUrlPath,
-            width: meta.orientation === 6 || meta.orientation === 8 ? meta.height : meta.width,
-            height: meta.orientation === 6 || meta.orientation === 8 ? meta.width : meta.height,
+      const meta = await sharp(processFilePath).metadata()
+      if (webpQuality > 0) {
+        if (meta.format && meta.format !== 'gif') {
+          if (meta.orientation && [3,6,8].includes(meta.orientation)) {
+            const angle = (meta.orientation === 6) ? 90 : (meta.orientation === 8) ? -90 : 180
+            await sharp(processFilePath).rotate(angle).webp({ quality: webpQuality }).toFile(webpPath)
+            return {
+              path: webpUrlPath,
+              width: meta.orientation === 6 || meta.orientation === 8 ? meta.height : meta.width,
+              height: meta.orientation === 6 || meta.orientation === 8 ? meta.width : meta.height,
+            }
+          } else {
+            await sharp(processFilePath).webp({ quality: webpQuality }).toFile(webpPath)
+            return {
+              path: webpUrlPath,
+              width: meta.width,
+              height: meta.height,
+            }
           }
         } else {
-          await sharp(processFilePath).webp({ quality: webpQuality }).toFile(webpPath)
           return {
-            path: webpUrlPath,
+            path: processUrlPath,
             width: meta.width,
             height: meta.height,
           }
@@ -469,29 +486,22 @@ export const saveImage = async (imageUrl: string, prefix: string): Promise<Image
           height: meta.height,
         }
       }
-    } else {
-      return {
-        path: processUrlPath,
-        width: meta.width,
-        height: meta.height,
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : String(e)
+
+      if (errorMessage.includes('Support for this compression format has not been built in')) {
+        const unsupportedMessage = `HEIC/HEIF image with unsupported compression format detected -- path: ${processFilePath}, url: ${imageUrl}. This image may not display in browsers other than Safari. Consider using a different image format or re-encoding the HEIC file.`
+        if (debug) {
+          console.log(unsupportedMessage)
+        }
+        console.warn(unsupportedMessage)
+      } else if (debug) {
+        console.log(`saveImage webp convert error -- path: ${processFilePath}, url: ${imageUrl}, message: ${errorMessage}`)
       }
     }
-  } catch (e) {
-    const errorMessage = e instanceof Error ? e.message : String(e)
 
-    // Check if the error is due to unsupported HEIC/HEIF compression format
-    if (errorMessage.includes('Support for this compression format has not been built in')) {
-      const unsupportedMessage = `HEIC/HEIF image with unsupported compression format detected -- path: ${processFilePath}, url: ${imageUrl}. This image may not display in browsers other than Safari. Consider using a different image format or re-encoding the HEIC file.`
-      if (debug) {
-        console.log(unsupportedMessage)
-      }
-      console.warn(unsupportedMessage)
-    } else if (debug) {
-      console.log(`saveImage webp convert error -- path: ${processFilePath}, url: ${imageUrl}, message: ${errorMessage}`)
-    }
-  }
-
-  return { path: processUrlPath }
+    return { path: processUrlPath }
+  })
 }
 
 export const decodeHtmlEntities = (text: string): string => {

--- a/src/exporter/files.ts
+++ b/src/exporter/files.ts
@@ -311,7 +311,7 @@ export async function saveFile (fileUrl: string, prefix: string) {
       try {
         let res: HttpGetResponse
         res = await httpsGetWithFollowRedirects(fileUrl)
-        if (res.statusCode >= 400 && res.statusCode < 500 && imageDir !== urlWithoutQuerystring) {
+        if (res.statusCode >= 400 && res.statusCode < 500 && fileUrl !== urlWithoutQuerystring) {
           res = await httpsGetWithFollowRedirects(urlWithoutQuerystring)
           if (res.statusCode >= 400 && res.statusCode < 500) {
             throw new Error(`retry download to ${urlWithoutQuerystring} but failed`)
@@ -398,7 +398,7 @@ export const saveImage = async (imageUrl: string, prefix: string): Promise<Image
       try {
         let res: HttpGetResponse
         res = await httpsGetWithFollowRedirects(imageUrl)
-        if (res.statusCode >= 400 && res.statusCode < 500 && imageDir !== urlWithoutQuerystring) {
+        if (res.statusCode >= 400 && res.statusCode < 500 && imageUrl !== urlWithoutQuerystring) {
           res = await httpsGetWithFollowRedirects(urlWithoutQuerystring)
           if (res.statusCode >= 400 && res.statusCode < 500) {
             throw new Error(`retry download to ${urlWithoutQuerystring} but failed`)

--- a/src/exporter/files.ts
+++ b/src/exporter/files.ts
@@ -264,11 +264,14 @@ export async function readCache<T> (f: string): Promise<T> {
 }
 
 export async function writeCache (f: string, data: unknown): Promise<void> {
-  const tmp = `${f}.${process.pid}.tmp`
+  const tmp = `${f}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`
   try {
     await writeFile(tmp, JSON.stringify(data), 'utf8')
     await fs.promises.rename(tmp, f)
-  } catch {
+  } catch (e) {
+    if (debug) {
+      console.log(`writeCache error -- path: ${f}, message: ${e}`)
+    }
     try { await fs.promises.unlink(tmp) } catch {}
   }
 }

--- a/src/exporter/mutex.test.ts
+++ b/src/exporter/mutex.test.ts
@@ -28,7 +28,7 @@ test('withFileLock executes operation when no lock exists', async () => {
   }
 
   const result = await withFileLock('test-key-1', operation)
-  
+
   assert.equal(result, 'success')
   assert.ok(executed)
 })
@@ -38,7 +38,7 @@ test('withFileLock returns operation result', async () => {
   const operation = async () => expectedResult
 
   const result = await withFileLock('test-key-2', operation)
-  
+
   assert.equal(result, expectedResult)
 })
 
@@ -58,7 +58,7 @@ test('withFileLock handles operation errors', async () => {
 test('withFileLock creates and removes lock file', async () => {
   const testCacheDir = path.join(process.cwd(), '.cache', 'locks')
   const lockFile = path.join(testCacheDir, 'test-key-4.lock')
-  
+
   let lockExistsDuringOperation = false
   const operation = async () => {
     try {
@@ -71,9 +71,9 @@ test('withFileLock creates and removes lock file', async () => {
   }
 
   await withFileLock('test-key-4', operation)
-  
+
   assert.ok(lockExistsDuringOperation, 'Lock file should exist during operation')
-  
+
   // Lock file should be removed after operation
   try {
     await fs.access(lockFile)
@@ -87,15 +87,15 @@ test('withFileLock prevents concurrent execution', async () => {
   let executions = 0
   let concurrentCount = 0
   let maxConcurrent = 0
-  
+
   const operation = async () => {
     concurrentCount++
     maxConcurrent = Math.max(maxConcurrent, concurrentCount)
     executions++
-    
+
     // Simulate some work
     await new Promise(resolve => setTimeout(resolve, 50))
-    
+
     concurrentCount--
     return executions
   }
@@ -104,9 +104,9 @@ test('withFileLock prevents concurrent execution', async () => {
   const promises = Array.from({ length: 3 }, () => 
     withFileLock('test-key-5', operation)
   )
-  
+
   const results = await Promise.all(promises)
-  
+
   assert.equal(maxConcurrent, 1, 'Only one operation should run at a time')
   assert.equal(executions, 3, 'All operations should complete')
   assert.equal(results.sort().join(','), '1,2,3', 'Results should be sequential')
@@ -114,23 +114,23 @@ test('withFileLock prevents concurrent execution', async () => {
 
 test('withFileLock respects timeout option', async () => {
   const lockKey = 'test-key-6'
-  
+
   // First operation holds lock for longer than timeout
   const longOperation = async () => {
     await new Promise(resolve => setTimeout(resolve, 200))
     return 'long'
   }
-  
+
   const shortTimeout = async () => {
     return 'short'
   }
 
   // Start long operation
   const longPromise = withFileLock(lockKey, longOperation)
-  
+
   // Wait a bit to ensure first operation gets the lock
   await new Promise(resolve => setTimeout(resolve, 10))
-  
+
   // Try to get lock with short timeout
   try {
     await withFileLock(lockKey, shortTimeout, { timeout: 100 })
@@ -138,7 +138,7 @@ test('withFileLock respects timeout option', async () => {
   } catch (error: any) {
     assert.match(error.message, /Failed to acquire lock/)
   }
-  
+
   // Wait for first operation to complete
   const result = await longPromise
   assert.equal(result, 'long')
@@ -147,7 +147,7 @@ test('withFileLock respects timeout option', async () => {
 test('withFileLock respects retryInterval option', async () => {
   const lockKey = 'test-key-7'
   const retryTimes: number[] = []
-  
+
   // Mock setTimeout to track retry intervals
   const originalSetTimeout = setTimeout
   const mockSetTimeout = td.func<typeof setTimeout>()
@@ -156,29 +156,29 @@ test('withFileLock respects retryInterval option', async () => {
       retryTimes.push(delay)
       return originalSetTimeout(fn, delay)
     })
-  
+
   td.replace(global, 'setTimeout', mockSetTimeout)
-  
+
   // First operation holds lock briefly
   const firstOperation = async () => {
     await new Promise(resolve => originalSetTimeout(resolve, 30))
     return 'first'
   }
-  
+
   const secondOperation = async () => 'second'
 
   // Start first operation
   const firstPromise = withFileLock(lockKey, firstOperation)
-  
+
   // Wait a bit then start second with custom retry interval
   await new Promise(resolve => originalSetTimeout(resolve, 10))
   const secondPromise = withFileLock(lockKey, secondOperation, { retryInterval: 25 })
-  
+
   await Promise.all([firstPromise, secondPromise])
-  
+
   // Should have retried with custom interval
   assert.ok(retryTimes.some(time => time === 25))
-  
+
   td.reset()
 })
 
@@ -186,10 +186,10 @@ test('withFileLock handles stale lock cleanup', async () => {
   const lockKey = 'test-key-8'
   const testCacheDir = path.join(process.cwd(), '.cache', 'locks')
   const lockFile = path.join(testCacheDir, `${lockKey}.lock`)
-  
+
   // Create directory if it doesn't exist
   await fs.mkdir(testCacheDir, { recursive: true })
-  
+
   // Create a stale lock file with a non-existent PID
   const staleLockData = JSON.stringify({
     pid: 999999, // Very unlikely to be a real PID
@@ -197,11 +197,11 @@ test('withFileLock handles stale lock cleanup', async () => {
     key: lockKey
   })
   await fs.writeFile(lockFile, staleLockData)
-  
+
   // Set file modification time to make it appear old
   const oldTime = new Date(Date.now() - 120000)
   await fs.utimes(lockFile, oldTime, oldTime)
-  
+
   let executed = false
   const operation = async () => {
     executed = true
@@ -210,7 +210,7 @@ test('withFileLock handles stale lock cleanup', async () => {
 
   // Should clean up stale lock and execute
   const result = await withFileLock(lockKey, operation, { maxAge: 60000 })
-  
+
   assert.equal(result, 'cleaned')
   assert.ok(executed)
 })
@@ -219,10 +219,10 @@ test('withFileLock preserves lock from live process', async () => {
   const lockKey = 'test-key-9'
   const testCacheDir = path.join(process.cwd(), '.cache', 'locks')
   const lockFile = path.join(testCacheDir, `${lockKey}.lock`)
-  
+
   // Create directory if it doesn't exist
   await fs.mkdir(testCacheDir, { recursive: true })
-  
+
   // Create a lock file with current process PID (simulating active lock)
   const activeLockData = JSON.stringify({
     pid: process.pid,
@@ -230,11 +230,11 @@ test('withFileLock preserves lock from live process', async () => {
     key: lockKey
   })
   await fs.writeFile(lockFile, activeLockData)
-  
+
   // Set file modification time to make it appear old
   const oldTime = new Date(Date.now() - 90000)
   await fs.utimes(lockFile, oldTime, oldTime)
-  
+
   const operation = async () => 'should-timeout'
 
   // Should timeout because lock is from live process
@@ -244,20 +244,20 @@ test('withFileLock preserves lock from live process', async () => {
   } catch (error: any) {
     assert.match(error.message, /Failed to acquire lock/)
   }
-  
+
   // Clean up
   await fs.unlink(lockFile).catch(() => {})
 })
 
 test('withFileLock works with different lock keys simultaneously', async () => {
   const results: string[] = []
-  
+
   const operation1 = async () => {
     await new Promise(resolve => setTimeout(resolve, 30))
     results.push('op1')
     return 'result1'
   }
-  
+
   const operation2 = async () => {
     await new Promise(resolve => setTimeout(resolve, 30))
     results.push('op2')
@@ -269,7 +269,7 @@ test('withFileLock works with different lock keys simultaneously', async () => {
     withFileLock('key-a', operation1),
     withFileLock('key-b', operation2)
   ])
-  
+
   assert.equal(result1, 'result1')
   assert.equal(result2, 'result2')
   assert.equal(results.length, 2)

--- a/src/exporter/mutex.ts
+++ b/src/exporter/mutex.ts
@@ -1,7 +1,6 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 import { cacheDir, debug } from './variables.js'
-import { createDirWhenNotfound } from './files.js'
 
 interface LockOptions {
   timeout?: number // Lock acquisition timeout (milliseconds)
@@ -27,7 +26,7 @@ export async function withFileLock<T>(
   const lockDir = path.join(cacheDir, 'locks')
   const lockFile = path.join(lockDir, `${key}.lock`)
 
-  await createDirWhenNotfound(lockDir)
+  await fs.mkdir(lockDir, { recursive: true })
 
   const startTime = Date.now()
   let fd: fs.FileHandle | null = null

--- a/src/exporter/mutex.ts
+++ b/src/exporter/mutex.ts
@@ -26,20 +26,20 @@ export async function withFileLock<T>(
   const opts = { ...DEFAULT_OPTIONS, ...options }
   const lockDir = path.join(cacheDir, 'locks')
   const lockFile = path.join(lockDir, `${key}.lock`)
-  
+
   await createDirWhenNotfound(lockDir)
-  
+
   const startTime = Date.now()
   let fd: fs.FileHandle | null = null
-  
+
   while (Date.now() - startTime < opts.timeout) {
     try {
       // Cleanup stale lock files
       await cleanupStalelock(lockFile, opts.maxAge)
-      
+
       // Create lock file exclusively
       fd = await fs.open(lockFile, 'wx')
-      
+
       // Write process ID and timestamp
       const lockData = JSON.stringify({
         pid: process.pid,
@@ -47,11 +47,11 @@ export async function withFileLock<T>(
         key
       })
       await fd.writeFile(lockData)
-      
+
       if (debug) {
         console.log(`Lock acquired: ${key} (pid: ${process.pid})`)
       }
-      
+
       // Execute operation
       try {
         const result = await operation()
@@ -60,7 +60,7 @@ export async function withFileLock<T>(
         // Release lock
         await releaseLock(fd, lockFile, key)
       }
-      
+
     } catch (error: any) {
       if (error.code === 'EEXIST') {
         // Lock file already exists - wait and retry
@@ -70,7 +70,7 @@ export async function withFileLock<T>(
       throw error
     }
   }
-  
+
   throw new Error(`Failed to acquire lock for "${key}" within ${opts.timeout}ms`)
 }
 
@@ -81,11 +81,11 @@ async function cleanupStalelock(lockFile: string, maxAge: number): Promise<void>
   try {
     const stats = await fs.stat(lockFile)
     const age = Date.now() - stats.mtime.getTime()
-    
+
     if (age > maxAge) {
       const lockData = await fs.readFile(lockFile, 'utf-8')
       const lock = JSON.parse(lockData)
-      
+
       // Check if process is alive
       if (!isProcessAlive(lock.pid)) {
         await fs.unlink(lockFile)

--- a/src/exporter/mutex.ts
+++ b/src/exporter/mutex.ts
@@ -34,7 +34,7 @@ export async function withFileLock<T>(
   while (Date.now() - startTime < opts.timeout) {
     try {
       // Cleanup stale lock files
-      await cleanupStalelock(lockFile, opts.maxAge)
+      await cleanupStaleLock(lockFile, opts.maxAge)
 
       // Create lock file exclusively
       fd = await fs.open(lockFile, 'wx')
@@ -76,7 +76,7 @@ export async function withFileLock<T>(
 /**
  * Cleanup stale lock files
  */
-async function cleanupStalelock(lockFile: string, maxAge: number): Promise<void> {
+async function cleanupStaleLock(lockFile: string, maxAge: number): Promise<void> {
   try {
     const stats = await fs.stat(lockFile)
     const age = Date.now() - stats.mtime.getTime()


### PR DESCRIPTION
## Summary
- Apply `withFileLock` mutex to `saveFile` and `saveImage` to prevent concurrent write/read race conditions on the same file path during Next.js parallel page rendering — this is the root cause of intermittent SIGBUS errors (libvips uses mmap internally, and a concurrent truncate/rewrite of a mapped file triggers SIGBUS)
- Fix `saveFile` missing `writeStream.on('finish')` wait — previously only waited on HTTP response end, not disk flush completion
- Make `writeCache` atomic using tmp-file-then-rename pattern to prevent corrupted JSON from concurrent writes

## Test plan
- [x] All 51 existing tests in `files.test.ts` pass
- [x] All 10 existing tests in `mutex.test.ts` pass
- [x] TypeScript type check passes (`tsc --noEmit`)
- [ ] Verify SIGBUS no longer occurs in GitHub Actions Next.js builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)