### PR TITLE
Fix iconRegexps quote leak and extend default lock timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotion",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotion",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "@notionhq/client": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotion",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "license": "MIT",
   "repository": "linyows/rotion",
   "description": "This is react components that uses the notion API to display the notion's database and page.",

--- a/src/exporter/files.test.ts
+++ b/src/exporter/files.test.ts
@@ -352,6 +352,16 @@ const testsIconRegex = [
     '<link rel="shortcut icon" type="image/x-icon" href="/assets/favicon-test.ico" />',
     '/assets/favicon-test.ico',
   ],
+  // The captured href must not include the trailing `"` even though `[^\s>]+`
+  // alone would also accept it. See iconRegexps in files.ts.
+  [
+    '<link rel="shortcut icon" href="/favicon.ico"/>',
+    '/favicon.ico',
+  ],
+  [
+    '<link rel="shortcut icon" href="https://example.com/favicon.ico">',
+    'https://example.com/favicon.ico',
+  ],
 ]
 for (const t of testsIconRegex) {
   const [tag, path] = t

--- a/src/exporter/files.ts
+++ b/src/exporter/files.ts
@@ -594,12 +594,12 @@ export const iconRegexps = [
   /<link\s+rel="icon"\s+href="?([^"]+)"?\s*?\/?>/,
   /<link\s+rel="icon".*?href="?([^"]+)"?/,
   /<link\s+rel="shortcut icon"\s+type="image\/x-icon"\s+href="?([^"]+)"?\s?\/?>/,
-  /<link\s+rel="shortcut icon"\s+href="?([^\s>]+)"?\s?\/?>/,
+  /<link\s+rel="shortcut icon"\s+href="?([^"\s>]+)"?\s?\/?>/,
   /<link\s+href="?([^"]+)"?\s+rel="(shortcut icon|icon shortcut)"(\s+type="image\/x-icon")?\s?\/?>/,
   /<link\s+href="?([^"]+)"?\s+rel="icon"\s+sizes="[^"]+"\s+type="image\/[^"]"\s*\/?>/,
   /type="image\/x-icon"\s+href="?([^"]+)"?/,
   /rel="icon"\s+href="?([^"]+)"?/,
-  /rel="shortcut icon"\s+href="?([^\s>]+)"?/,
+  /rel="shortcut icon"\s+href="?([^"\s>]+)"?/,
 ]
 
 export const findImage = (html: string): string | null => {

--- a/src/exporter/mutex.ts
+++ b/src/exporter/mutex.ts
@@ -9,7 +9,9 @@ interface LockOptions {
 }
 
 const DEFAULT_OPTIONS: Required<LockOptions> = {
-  timeout: 30000, // 30 seconds
+  timeout: 600000, // 10 minutes — must accommodate long operations like
+                   // FetchDatabase that wrap many sequential image downloads
+                   // inside a single critical section.
   retryInterval: 100, // 100ms
   maxAge: 60000, // 1 minute
 }


### PR DESCRIPTION
## Summary

- **Fix `iconRegexps` quote leak in `src/exporter/files.ts`** — the two regex entries that used `[^\s>]+` greedily included a trailing `"` from quoted `href` attributes, producing filenames like `html-icon-...ico"` that broke artifact uploads on CI. Excluded `"` from the captured class.
- **Bump default `withFileLock` timeout to 10 minutes in `src/exporter/mutex.ts`** — `FetchDatabase` serializes Notion API calls and many sequential image downloads inside a single critical section, easily exceeding the previous 30s default. With multiple Next.js workers contending for the same database lock, secondary callers timed out before the holder finished. Per-call overrides via `LockOptions` are unchanged.
- **Bump version to v3.4.1**

## Background

Hit on cognano.co.jp build pipeline after upgrading to v3.4.0:

- EN build: `The path for one of the files in artifact is not valid: /images/html-icon-...ico". Contains the following character: Double quote "`
- JA build: `Error: Failed to acquire lock for "database-..." within 30000ms` during `/about` prerender (10 `Promise.all` calls × 3 Next.js workers).

## Test plan

- [x] `npm run exporter:test` — all 129 tests pass (added 2 new icon regex cases for quoted `href`)
- [x] `npm run exporter:build` succeeds; `dist/exporter/files.js` and `dist/exporter/mutex.js` reflect the changes
- [ ] Verify cognano.co.jp production build no longer fails after consuming v3.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)