### PR TITLE
Fix saveImage hang deadlock and harden iconRegexps + webp handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotion",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotion",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "dependencies": {
         "@notionhq/client": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotion",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "license": "MIT",
   "repository": "linyows/rotion",
   "description": "This is react components that uses the notion API to display the notion's database and page.",

--- a/src/exporter/files.test.ts
+++ b/src/exporter/files.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises'
+import http from 'http'
 import { test } from 'uvu'
 import * as td from 'testdouble'
 import * as assert from 'uvu/assert'
@@ -362,6 +363,28 @@ const testsIconRegex = [
     '<link rel="shortcut icon" href="https://example.com/favicon.ico">',
     'https://example.com/favicon.ico',
   ],
+  // Unquoted href followed by additional attributes — the regex must
+  // capture only the URL, not bleed across `>` or whitespace.
+  [
+    '<link rel="icon" href=/foo.png class="x">',
+    '/foo.png',
+  ],
+  [
+    '<link rel="icon" type="image/x-icon" href=/bar.ico />',
+    '/bar.ico',
+  ],
+  // The leak we observed in cognano builds: nature.com served a link tag
+  // whose captured href ended with `>` and the saved file became
+  // `something.png>`, which then crashed sharp with "unsupported image
+  // format". The fix tightens `[^"]+` URL captures to `[^"\s>]+`.
+  [
+    '<link rel="icon" type="image/png" sizes="48x48" href=/static/favicon-48x48.png>',
+    '/static/favicon-48x48.png',
+  ],
+  [
+    '<link rel="icon" href=/foo.svg/>',
+    '/foo.svg',
+  ],
 ]
 for (const t of testsIconRegex) {
   const [tag, path] = t
@@ -488,6 +511,138 @@ test('saveFile writeStream finish is awaited (file is complete on return)', asyn
   const stats = await fs.stat(filePath)
   assert.ok(stats.size > 0, 'file should have content')
   assert.equal(stats.size, result.size, 'reported size should match actual file size')
+})
+
+// --- Stream hang regression tests ---
+//
+// Reproduce the deadlock observed in cognano builds: a remote server returns
+// response headers and a few bytes, then stops sending data. The current
+// `await res.end` in saveImage/saveFile hangs forever in this case, because
+// `req.setTimeout` aborts the request without emitting the 'end' event that
+// the awaited promise listens for. The lock around saveImage is therefore
+// never released and downstream workers deadlock.
+//
+// After the fix, saveImage/saveFile must reject within roughly the configured
+// timeout window (default 1500ms) instead of hanging.
+
+async function startStallingServer (): Promise<{ port: number, close: () => Promise<void> }> {
+  const sockets: import('net').Socket[] = []
+  const server = http.createServer((_req, res) => {
+    // Send headers and a few bytes, then deliberately never end.
+    // No Content-Length, so the client cannot know the body is complete.
+    res.writeHead(200, { 'Content-Type': 'image/png' })
+    res.write(Buffer.alloc(64, 0))
+  })
+  server.on('connection', (socket) => { sockets.push(socket) })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const addr = server.address()
+  if (!addr || typeof addr === 'string') throw new Error('failed to bind test server')
+  return {
+    port: addr.port,
+    close: async () => {
+      for (const s of sockets) s.destroy()
+      await new Promise<void>(resolve => server.close(() => resolve()))
+    },
+  }
+}
+
+test('saveImage rejects (does not hang) when remote stalls mid-response', async () => {
+  const { port, close } = await startStallingServer()
+  // Unique URL per run so the existsSync fast-path in saveImage doesn't
+  // bypass the download (which is what we are exercising).
+  const url = `http://127.0.0.1:${port}/stall-img-${Date.now()}-${Math.random().toString(36).slice(2)}.png`
+  try {
+    const start = Date.now()
+    const TEST_BUDGET = 8000 // generous: 1500ms ROTION_TIMEOUT default + slack
+    let outcome: 'resolved' | 'rejected' | 'hang' = 'hang'
+
+    await Promise.race([
+      files.saveImage(url, 'stall-test-img')
+        .then(() => { outcome = 'resolved' })
+        .catch(() => { outcome = 'rejected' }),
+      new Promise<void>(resolve => setTimeout(resolve, TEST_BUDGET)),
+    ])
+
+    const elapsed = Date.now() - start
+    assert.equal(
+      outcome,
+      'rejected',
+      `saveImage should reject when remote stalls (elapsed=${elapsed}ms, outcome=${outcome})`,
+    )
+    assert.ok(
+      elapsed < TEST_BUDGET,
+      `saveImage should fail fast, took ${elapsed}ms (>= ${TEST_BUDGET}ms budget)`,
+    )
+  } finally {
+    await close()
+  }
+})
+
+test('saveFile rejects (does not hang) when remote stalls mid-response', async () => {
+  const { port, close } = await startStallingServer()
+  const url = `http://127.0.0.1:${port}/stall-file-${Date.now()}-${Math.random().toString(36).slice(2)}.bin`
+  try {
+    const start = Date.now()
+    const TEST_BUDGET = 8000
+    let outcome: 'resolved' | 'rejected' | 'hang' = 'hang'
+
+    await Promise.race([
+      files.saveFile(url, 'stall-test-file')
+        .then(() => { outcome = 'resolved' })
+        .catch(() => { outcome = 'rejected' }),
+      new Promise<void>(resolve => setTimeout(resolve, TEST_BUDGET)),
+    ])
+
+    const elapsed = Date.now() - start
+    assert.equal(
+      outcome,
+      'rejected',
+      `saveFile should reject when remote stalls (elapsed=${elapsed}ms, outcome=${outcome})`,
+    )
+    assert.ok(
+      elapsed < TEST_BUDGET,
+      `saveFile should fail fast, took ${elapsed}ms (>= ${TEST_BUDGET}ms budget)`,
+    )
+  } finally {
+    await close()
+  }
+})
+
+// --- saveImage webp same-file regression test ---
+//
+// When the source URL ends in `.webp`, replaceExt(urlPath, '.webp') yields
+// the same path as filePath, so the conversion step
+// `sharp(filePath).webp().toFile(webpPath)` fails with
+// "Cannot use same file for input and output" and the function returns
+// without populated width/height. The fix short-circuits the re-encode
+// when the downloaded file is already at the target webp path.
+
+test('saveImage downloads .webp URL without "Cannot use same file" error', async () => {
+  const sharp = (await import('sharp')).default
+  const webpBuffer = await sharp({
+    create: { width: 12, height: 8, channels: 3, background: { r: 12, g: 34, b: 56 } },
+  }).webp().toBuffer()
+
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'image/webp', 'Content-Length': String(webpBuffer.length) })
+    res.end(webpBuffer)
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const addr = server.address()
+  if (!addr || typeof addr === 'string') throw new Error('failed to bind test server')
+  const port = addr.port
+  const url = `http://127.0.0.1:${port}/test-webp-${Date.now()}-${Math.random().toString(36).slice(2)}.webp`
+
+  try {
+    const ipws = await files.saveImage(url, 'webp-saveimage-test')
+    assert.match(ipws.path, /^\/images\/.*\.webp$/, `expected .webp path, got: ${ipws.path}`)
+    // The fix should still report metadata (width/height) instead of bailing
+    // out after the sharp error.
+    assert.equal(ipws.width, 12, `width should match source, got: ${ipws.width}`)
+    assert.equal(ipws.height, 8, `height should match source, got: ${ipws.height}`)
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  }
 })
 
 test.run()

--- a/src/exporter/files.ts
+++ b/src/exporter/files.ts
@@ -1,5 +1,7 @@
 import fs from 'fs'
 import { mkdir, stat, unlink } from 'node:fs/promises'
+import { pipeline } from 'node:stream/promises'
+import type { Readable } from 'node:stream'
 import https from 'https'
 import http from 'http'
 import path from 'path'
@@ -317,13 +319,12 @@ export async function saveFile (fileUrl: string, prefix: string) {
             throw new Error(`retry download to ${urlWithoutQuerystring} but failed`)
           }
         }
+        // Use stream.pipeline so that source-side errors (request abort,
+        // socket close, network stall after `req.setTimeout` fires) reject
+        // and clean up the write stream instead of leaving the
+        // `writeStream.on('finish')` promise dangling forever.
         const writeStream = fs.createWriteStream(filePath)
-        res.pipe(writeStream)
-        await res.end
-        await new Promise<void>((resolve, reject) => {
-          writeStream.on('finish', resolve)
-          writeStream.on('error', reject)
-        })
+        await pipeline(res as unknown as Readable, writeStream)
       } catch (e) {
         const errorMessage = `saveFile download error -- path: ${filePath}, url: ${fileUrl}, message: ${e}`
         if (debug) {
@@ -404,13 +405,12 @@ export const saveImage = async (imageUrl: string, prefix: string): Promise<Image
             throw new Error(`retry download to ${urlWithoutQuerystring} but failed`)
           }
         }
+        // Use stream.pipeline so that source-side errors (request abort,
+        // socket close, network stall after `req.setTimeout` fires) reject
+        // and clean up the write stream instead of leaving the
+        // `writeStream.on('finish')` promise dangling forever.
         const writeStream = fs.createWriteStream(filePath)
-        res.pipe(writeStream)
-        await res.end
-        await new Promise<void>((resolve, reject) => {
-          writeStream.on('finish', resolve)
-          writeStream.on('error', reject)
-        })
+        await pipeline(res as unknown as Readable, writeStream)
       } catch (e) {
         const errorMessage = `saveImage download error -- path: ${filePath}, url: ${imageUrl}, message: ${e}`
         if (debug) {
@@ -422,6 +422,21 @@ export const saveImage = async (imageUrl: string, prefix: string): Promise<Image
 
     if (ext === '.ico' || ext === '.svg') {
       return { path: urlPath }
+    }
+
+    // Source is already webp — re-encoding it would point sharp at the same
+    // path for input and output ("Cannot use same file for input and output")
+    // and discard width/height. Just measure metadata and return.
+    if (ext === '.webp') {
+      try {
+        const meta = await sharp(filePath).metadata()
+        return { path: urlPath, width: meta.width, height: meta.height }
+      } catch (e) {
+        if (debug) {
+          console.log(`sharp.metadata() error -- path: ${urlPath}, message: ${e}`)
+        }
+        return { path: urlPath }
+      }
     }
 
     /* Convert HEIC/HEIF to PNG first if needed */
@@ -589,17 +604,23 @@ export const imageRegexps = [
   /name="twitter:image"\s+content="([^"]+)"/,
 ]
 
+// URL captures use `[^"\s>]+?` (lazy) followed by a lookahead requiring
+// `"`, whitespace, `>`, or `/>` so that an unquoted href like
+// `href=/foo.svg/>` captures `/foo.svg` and not `/foo.svg/`. Without this
+// the trailing `/` of a self-closing tag bleeds into the saved filename
+// and breaks downstream sharp processing. `[^"]+` is preserved for
+// non-URL captures (e.g. `sizes="..."`).
 export const iconRegexps = [
-  /<link\s+href="?([^"]+)"?\s+rel="icon"/,
-  /<link\s+rel="icon"\s+href="?([^"]+)"?\s*?\/?>/,
-  /<link\s+rel="icon".*?href="?([^"]+)"?/,
-  /<link\s+rel="shortcut icon"\s+type="image\/x-icon"\s+href="?([^"]+)"?\s?\/?>/,
-  /<link\s+rel="shortcut icon"\s+href="?([^"\s>]+)"?\s?\/?>/,
-  /<link\s+href="?([^"]+)"?\s+rel="(shortcut icon|icon shortcut)"(\s+type="image\/x-icon")?\s?\/?>/,
-  /<link\s+href="?([^"]+)"?\s+rel="icon"\s+sizes="[^"]+"\s+type="image\/[^"]"\s*\/?>/,
-  /type="image\/x-icon"\s+href="?([^"]+)"?/,
-  /rel="icon"\s+href="?([^"]+)"?/,
-  /rel="shortcut icon"\s+href="?([^"\s>]+)"?/,
+  /<link\s+href="?([^"\s>]+?(?=["\s>]|\/>))"?\s+rel="icon"/,
+  /<link\s+rel="icon"\s+href="?([^"\s>]+?(?=["\s>]|\/>))"?\s*?\/?>/,
+  /<link\s+rel="icon".*?href="?([^"\s>]+?(?=["\s>]|\/>))"?/,
+  /<link\s+rel="shortcut icon"\s+type="image\/x-icon"\s+href="?([^"\s>]+?(?=["\s>]|\/>))"?\s?\/?>/,
+  /<link\s+rel="shortcut icon"\s+href="?([^"\s>]+?(?=["\s>]|\/>))"?\s?\/?>/,
+  /<link\s+href="?([^"\s>]+?(?=["\s>]|\/>))"?\s+rel="(shortcut icon|icon shortcut)"(\s+type="image\/x-icon")?\s?\/?>/,
+  /<link\s+href="?([^"\s>]+?(?=["\s>]|\/>))"?\s+rel="icon"\s+sizes="[^"]+"\s+type="image\/[^"]"\s*\/?>/,
+  /type="image\/x-icon"\s+href="?([^"\s>]+?(?=["\s>]|\/>))"?/,
+  /rel="icon"\s+href="?([^"\s>]+?(?=["\s>]|\/>))"?/,
+  /rel="shortcut icon"\s+href="?([^"\s>]+?(?=["\s>]|\/>))"?/,
 ]
 
 export const findImage = (html: string): string | null => {

--- a/src/exporter/files.ts
+++ b/src/exporter/files.ts
@@ -1,9 +1,9 @@
 import fs from 'fs'
 import { mkdir, stat, unlink } from 'node:fs/promises'
 import { pipeline } from 'node:stream/promises'
-import type { Readable } from 'node:stream'
 import https from 'https'
 import http from 'http'
+import type { IncomingMessage } from 'node:http'
 import path from 'path'
 import crypto from 'crypto'
 import { promisify } from 'util'
@@ -63,11 +63,14 @@ http.get[promisify.custom] = function getAsync (url: any) {
   })
 }
 
-interface HttpGetResponse {
-  pipe: Function
+// Extends IncomingMessage so it is a proper Readable stream (and works
+// directly with `stream.pipeline` without a cast). Overrides `end` with the
+// Promise we attach in the custom promisify above (resolved when the
+// response emits 'end'), and tightens `statusCode` to non-optional since
+// the response is only constructed after headers arrive.
+interface HttpGetResponse extends Omit<IncomingMessage, 'end' | 'statusCode'> {
   end: Promise<unknown>
   statusCode: number
-  rawHeaders: string[]
 }
 
 // https://oembed.com/
@@ -324,8 +327,12 @@ export async function saveFile (fileUrl: string, prefix: string) {
         // and clean up the write stream instead of leaving the
         // `writeStream.on('finish')` promise dangling forever.
         const writeStream = fs.createWriteStream(filePath)
-        await pipeline(res as unknown as Readable, writeStream)
+        await pipeline(res, writeStream)
       } catch (e) {
+        // Best-effort cleanup of any partial bytes pipeline managed to write
+        // before failing — otherwise the next call hits the existsSync()
+        // fast-path and serves a corrupted cached file.
+        try { await unlink(filePath) } catch {}
         const errorMessage = `saveFile download error -- path: ${filePath}, url: ${fileUrl}, message: ${e}`
         if (debug) {
           console.log(errorMessage)
@@ -410,8 +417,12 @@ export const saveImage = async (imageUrl: string, prefix: string): Promise<Image
         // and clean up the write stream instead of leaving the
         // `writeStream.on('finish')` promise dangling forever.
         const writeStream = fs.createWriteStream(filePath)
-        await pipeline(res as unknown as Readable, writeStream)
+        await pipeline(res, writeStream)
       } catch (e) {
+        // Best-effort cleanup of any partial bytes pipeline managed to write
+        // before failing — otherwise the next call hits the existsSync()
+        // fast-path and serves a corrupted cached file.
+        try { await unlink(filePath) } catch {}
         const errorMessage = `saveImage download error -- path: ${filePath}, url: ${imageUrl}, message: ${e}`
         if (debug) {
           console.log(errorMessage)

--- a/src/exporter/mutex.test.ts
+++ b/src/exporter/mutex.test.ts
@@ -306,7 +306,7 @@ test('withFileLock rejects with operationTimeout when operation hangs', async ()
   const hangingOperation = () => new Promise(() => { /* never resolves */ })
 
   const { outcome, error, elapsed } = await runWithBudget(
-    withFileLock(lockKey, hangingOperation, { operationTimeout: 200 } as any),
+    withFileLock(lockKey, hangingOperation, { operationTimeout: 200 }),
     3000,
   )
 
@@ -335,7 +335,7 @@ test('withFileLock allows next acquirer immediately after operationTimeout fires
   const aPromise = withFileLock(
     lockKey,
     () => new Promise(() => { /* never resolves */ }),
-    { operationTimeout: 200 } as any,
+    { operationTimeout: 200 },
   ).catch(e => e)
 
   // Give A time to acquire the lock.

--- a/src/exporter/mutex.test.ts
+++ b/src/exporter/mutex.test.ts
@@ -278,4 +278,83 @@ test('withFileLock works with different lock keys simultaneously', async () => {
   assert.ok(results.includes('op2'))
 })
 
-test.run() 
+// --- operationTimeout regression tests ---
+//
+// Defense-in-depth: even if an inner operation (e.g. a saveImage download)
+// hangs forever, withFileLock must release the lock and surface a timeout
+// error rather than letting the lock holder block all peers indefinitely.
+// This is what cascaded into the cognano build deadlock when saveImage's
+// `await res.end` never resolved after a request abort.
+
+// Helper: run a promise against a hard wall-clock budget so a hang shows up
+// as a clean assertion failure instead of locking up uvu.
+async function runWithBudget<T> (p: Promise<T>, budgetMs: number): Promise<{ outcome: 'resolved' | 'rejected' | 'hang', value?: T, error?: any, elapsed: number }> {
+  const start = Date.now()
+  let outcome: 'resolved' | 'rejected' | 'hang' = 'hang'
+  let value: T | undefined
+  let error: any
+  await Promise.race([
+    p.then(v => { outcome = 'resolved'; value = v })
+      .catch(e => { outcome = 'rejected'; error = e }),
+    new Promise<void>(resolve => setTimeout(resolve, budgetMs)),
+  ])
+  return { outcome, value, error, elapsed: Date.now() - start }
+}
+
+test('withFileLock rejects with operationTimeout when operation hangs', async () => {
+  const lockKey = 'test-op-timeout'
+  const hangingOperation = () => new Promise(() => { /* never resolves */ })
+
+  const { outcome, error, elapsed } = await runWithBudget(
+    withFileLock(lockKey, hangingOperation, { operationTimeout: 200 } as any),
+    3000,
+  )
+
+  assert.equal(outcome, 'rejected',
+    `withFileLock should reject when operation hangs longer than operationTimeout (outcome=${outcome}, elapsed=${elapsed}ms)`)
+  assert.ok(error, 'expected an error')
+  assert.match(error.message, /operation timed out|operationTimeout/i,
+    `error should mention operation timeout, got: ${error?.message}`)
+  assert.ok(elapsed >= 200 && elapsed < 2000,
+    `should fire near operationTimeout (~200ms), got ${elapsed}ms`)
+
+  // Lock file must be released so the next acquirer can proceed
+  const lockFile = path.join(process.cwd(), '.cache', 'locks', `${lockKey}.lock`)
+  try {
+    await fs.access(lockFile)
+    assert.unreachable(`lock file should be removed after operationTimeout, but exists: ${lockFile}`)
+  } catch {
+    // expected: file does not exist
+  }
+})
+
+test('withFileLock allows next acquirer immediately after operationTimeout fires', async () => {
+  const lockKey = 'test-op-timeout-handoff'
+
+  // Worker A holds the lock with a hanging operation.
+  const aPromise = withFileLock(
+    lockKey,
+    () => new Promise(() => { /* never resolves */ }),
+    { operationTimeout: 200 } as any,
+  ).catch(e => e)
+
+  // Give A time to acquire the lock.
+  await new Promise(resolve => setTimeout(resolve, 50))
+
+  // Worker B waits and should succeed once A's operationTimeout releases the lock.
+  const { outcome, value, elapsed } = await runWithBudget(
+    withFileLock(lockKey, async () => 'B', { timeout: 5000 }),
+    3000,
+  )
+
+  assert.equal(outcome, 'resolved',
+    `B should acquire after A's operationTimeout (outcome=${outcome}, elapsed=${elapsed}ms)`)
+  assert.equal(value, 'B')
+  assert.ok(elapsed < 2000, `B should acquire shortly after A's operationTimeout, took ${elapsed}ms`)
+
+  // A should have errored out, not silently hung
+  const aErr = await aPromise
+  assert.ok(aErr instanceof Error, 'A should have rejected with an error')
+})
+
+test.run()

--- a/src/exporter/mutex.ts
+++ b/src/exporter/mutex.ts
@@ -6,6 +6,11 @@ interface LockOptions {
   timeout?: number // Lock acquisition timeout (milliseconds)
   retryInterval?: number // Retry interval (milliseconds)
   maxAge?: number // Auto-cleanup time for stale lock files (milliseconds)
+  operationTimeout?: number // Hard upper bound on the wrapped operation
+                            // (milliseconds). Defense-in-depth: if the
+                            // operation hangs (e.g. a stalled HTTP download),
+                            // the lock is forcibly released and the call
+                            // rejects instead of blocking peers indefinitely.
 }
 
 const DEFAULT_OPTIONS: Required<LockOptions> = {
@@ -14,6 +19,9 @@ const DEFAULT_OPTIONS: Required<LockOptions> = {
                    // inside a single critical section.
   retryInterval: 100, // 100ms
   maxAge: 60000, // 1 minute
+  operationTimeout: 600000, // 10 minutes — same upper bound as `timeout` so a
+                            // hanging operation cannot keep the lock past the
+                            // window in which other waiters would give up.
 }
 
 /**
@@ -53,9 +61,10 @@ export async function withFileLock<T>(
         console.log(`Lock acquired: ${key} (pid: ${process.pid})`)
       }
 
-      // Execute operation
+      // Execute operation, bounded by operationTimeout so a hanging
+      // operation cannot wedge the lock indefinitely.
       try {
-        const result = await operation()
+        const result = await runWithOperationTimeout(operation, opts.operationTimeout, key)
         return result
       } finally {
         // Release lock
@@ -110,6 +119,32 @@ function isProcessAlive(pid: number): boolean {
     return true
   } catch {
     return false
+  }
+}
+
+/**
+ * Race the operation against an operation-level timeout. The operation may
+ * still continue running after the timeout fires (we cannot synchronously
+ * cancel an arbitrary Promise), but the lock will be released and an error
+ * propagated so peers waiting on the same lock can make progress.
+ */
+async function runWithOperationTimeout<T> (
+  operation: () => Promise<T>,
+  operationTimeout: number,
+  key: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`operation timed out for "${key}" after ${operationTimeout}ms`))
+    }, operationTimeout)
+    // Don't keep the event loop alive solely for the timeout.
+    if (typeof timer.unref === 'function') timer.unref()
+  })
+  try {
+    return await Promise.race([operation(), timeoutPromise])
+  } finally {
+    if (timer) clearTimeout(timer)
   }
 }
 


### PR DESCRIPTION
## Summary

Four cohesive fixes that together restore reliable cold-cache builds for users hitting parallel `saveImage` paths under realistic Notion content. All four were observed in the cognano.co.jp build pipeline; the deadlock is the headline issue, the others are bugs we surfaced while investigating it.

### 1. saveImage/saveFile no longer hang on remote stalls (the deadlock)

The previous code:

```ts
const writeStream = fs.createWriteStream(filePath)
res.pipe(writeStream)
await res.end
await new Promise<void>((resolve, reject) => {
  writeStream.on('finish', resolve)
  writeStream.on('error', reject)
})
```

hangs forever after `req.setTimeout` aborts the request: `res` is destroyed without emitting `end`, and the `writeStream` Promise never resolves because it only listens for `finish`/`error`. Because `saveImage` is wrapped in `withFileLock`, the lock is never released and every other worker waiting on the same key (e.g. the `database-...` lock around `FetchDatabase`) deadlocks.

Replaced the manual pipe+await with `stream.pipeline` so source-side errors and aborts propagate and clean up both ends.

### 2. `withFileLock` gains `operationTimeout` (defense-in-depth)

Default 10 minutes, matching the lock-acquisition timeout. Even if another inner operation hangs in the future, the lock is released and waiters get an error instead of stalling indefinitely.

### 3. `iconRegexps` no longer leak `>` or trailing `/` into the captured URL

`[^"]+` URL captures included `>` (cognano was saving files like `html-icon-...png>`, which then crashed sharp with "unsupported image format"). A first pass to `[^"\s>]+` greedy still pulled the `/` of self-closing tags into the URL (`/foo.svg/>` → `/foo.svg/`).

Switched URL captures to lazy `[^"\s>]+?` with a trailing lookahead `(?=["\s>]|\/>)` so the URL boundary is explicit. `[^"]+` is preserved for non-URL captures (e.g. `sizes="..."`).

### 4. saveImage early-returns for `.webp` sources

Alongside `.ico`/`.svg`. When the source is already webp, `replaceExt(urlPath, '.webp')` makes `webpPath === filePath`, so re-encoding via `sharp(filePath).webp().toFile(webpPath)` errors with `Cannot use same file for input and output` and the function loses width/height. The early return measures metadata once and returns.

## Test plan

- [x] `npm run exporter:test` — 138/138 pass (existing 129 + 9 new regression tests)
- [x] Cold-cache `bun run build` of cognano.co.jp (which previously deadlocked under v3.4.1) — 65/65 pages prerender in ~2.4 minutes with no hang
- [x] All four fixes have explicit failing-then-passing regression tests

## Background

Originally surfaced when the cognano.co.jp Production-EN/JA workflows started hanging at the prerender phase under v3.4.0/v3.4.1. The deadlock pattern was reproduced locally with `ROTION_DEBUG=true`: a `saveimage-...` lock acquired but never released, with a `Closing file descriptor on garbage collection` warning right after, and three workers all stuck on transitively related locks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)