### PR TITLE
Match the database property types to the notion api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotion",
-  "version": "3.5.7",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotion",
-      "version": "3.5.7",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@notionhq/client": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotion",
-  "version": "3.5.7",
+  "version": "3.6.0",
   "license": "MIT",
   "repository": "linyows/rotion",
   "description": "This is react components that uses the notion API to display the notion's database and page.",

--- a/src/exporter/types.ts
+++ b/src/exporter/types.ts
@@ -37,12 +37,12 @@ import type {
   LinkPreviewBlockObjectResponse,
   UnsupportedBlockObjectResponse,
   RichTextItemResponse,
+  NumberFormat,
   GetPagePropertyResponse,
   PageObjectResponse,
   UserObjectResponse,
   DatabaseObjectResponse,
   MentionRichTextItemResponse,
-  TextRichTextItemResponse,
   EquationRichTextItemResponse,
   PropertyItemListResponse,
 } from '@notionhq/client/build/src/api-endpoints.js'
@@ -379,35 +379,7 @@ export type DBPageBase = {
   properties: {}
 }
 
-export type DBProperties = Record<
-    string,
-    | { type: 'title', title: Array<RichTextItemResponse>, id: string }
-    | { type: 'rich_text', rich_text: Array<RichTextItemResponse>, id: string }
-    | { type: 'number', number: number | null, id: string }
-    | { type: 'url', url: string | null, id: string }
-    | { type: 'select', select: SelectPropertyResponse | null, id: string }
-    | { type: 'multi_select', multi_select: Array<SelectPropertyResponse>, id: string }
-    | { type: 'people', people: Array<PartialUserObjectResponse>, id: string }
-    | { type: 'email', email: string | null, id: string }
-    | { type: 'phone_number', phone_number: string | null, id: string }
-    | { type: 'date', date: DateResponse | null, id: string }
-    | { type: 'files', files: Array<
-      | { file: { url: string, expiry_time: string }, name: StringRequest, type?: 'file' }
-      | { external: { url: TextRequest }, name: StringRequest, type?: 'external' }
-      >, id: string }
-    | { type: 'checkbox', checkbox: boolean, id: string }
-    | { type: 'formula', formula:
-      | { type: 'string', string: string | null }
-      | { type: 'date', date: DateResponse | null }
-      | { type: 'number', number: number | null }
-      | { type: 'boolean', boolean: boolean | null }
-      , id: string }
-    | { type: 'relation', relation: Array<{ id: string }>, id: string }
-    | { type: 'created_time', created_time: string, id: string }
-    | { type: 'created_by', created_by: PartialUserObjectResponse, id: string }
-    | { type: 'last_edited_time', last_edited_time: string, id: string }
-    | { type: 'last_edited_by', last_edited_by: PartialUserObjectResponse, id: string }
-  >
+export type DBProperties = Record<string, DatabasePropertyValue>
 
 // https://github.com/makenotion/notion-sdk-js/blob/d3f6c1b41c0f814e39ed202c6aa3b4a7cfdca582/src/api-endpoints.ts#L10837-L11019
 export type QueryDatabaseResponseResult = | {
@@ -479,9 +451,15 @@ export type Parent =
 | { type: "data_source_id"; data_source_id: string }
 | { type: "agent_id"; agent_id: string }
 
-export type DatabaseProperty = DatabasePropertyConfigResponse
+// A database property has two shapes in the notion api: its schema, returned
+// in the `properties` of a data source, and the value it holds on a page,
+// returned in the `properties` of a page. They are not interchangeable -- a
+// select property is `{ options: [...] }` in the schema and a single option
+// in a page. `DatabasePropertyConfigResponse` is the former,
+// `DatabasePropertyValue` the latter.
+export type DatabaseProperty = DatabasePropertyValue
 
-export type DatabasePropertyConfigResponse =
+export type DatabasePropertyConfigResponse = DatabasePropertyConfigResponseCommon & (
   | NumberDatabasePropertyConfigResponse
   | FormulaDatabasePropertyConfigResponse
   | SelectDatabasePropertyConfigResponse
@@ -503,6 +481,15 @@ export type DatabasePropertyConfigResponse =
   | CreatedTimeDatabasePropertyConfigResponse
   | LastEditedByDatabasePropertyConfigResponse
   | LastEditedTimeDatabasePropertyConfigResponse
+  | ButtonDatabasePropertyConfigResponse
+  | VerificationDatabasePropertyConfigResponse
+)
+
+export type DatabasePropertyConfigResponseCommon = {
+  id: string
+  name: string
+  description: string | null
+}
 
 type RollupFunction =
   | "count"
@@ -530,28 +517,34 @@ type RollupFunction =
   | "percent_per_group"
   | "show_original"
 
+// An option of a select/multi_select/status property in the schema. The same
+// option on a page has no description, hence SelectPropertyResponse.
+export type SelectOptionResponse = SelectPropertyResponse & {
+  description: string | null
+}
+
+export type StatusOptionResponse = StatusPropertyResponse & {
+  description: string | null
+}
+
 export type NumberDatabasePropertyConfigResponse = {
   type: "number"
-  number: number | null
-  id: string
+  number: { format: NumberFormat }
 }
 
 export type FormulaDatabasePropertyConfigResponse = {
   type: "formula"
-  formula: NumberDatabasePropertyConfigResponse
-  id: string
+  formula: { expression: string }
 }
 
 export type SelectDatabasePropertyConfigResponse = {
   type: "select"
-  select: SelectPropertyResponse
-  id: string
+  select: { options: Array<SelectOptionResponse> }
 }
 
 export type MultiSelectDatabasePropertyConfigResponse = {
   type: "multi_select"
-  multi_select: SelectPropertyResponse[]
-  id: string
+  multi_select: { options: Array<SelectOptionResponse> }
 }
 
 export type StatusPropertyResponse = {
@@ -563,7 +556,7 @@ export type StatusPropertyResponse = {
 export type StatusDatabasePropertyConfigResponse = {
   type: "status"
   status: {
-    options: Array<StatusPropertyResponse>
+    options: Array<StatusOptionResponse>
     groups: Array<{
       id: StringRequest
       name: StringRequest
@@ -571,13 +564,11 @@ export type StatusDatabasePropertyConfigResponse = {
       option_ids: Array<string>
     }>
   }
-  id: string
 }
 
 export type SinglePropertyDatabasePropertyRelationConfigResponse = {
   type: "single_property"
   single_property: EmptyObject
-  database_id: IdRequest
 }
 
 export type DualPropertyDatabasePropertyRelationConfigResponse = {
@@ -586,17 +577,19 @@ export type DualPropertyDatabasePropertyRelationConfigResponse = {
     synced_property_id: StringRequest
     synced_property_name: StringRequest
   }
-  database_id: IdRequest
 }
 
-export type DatabasePropertyRelationConfigResponse =
+export type DatabasePropertyRelationConfigResponse = {
+  database_id: IdRequest
+  data_source_id: IdRequest
+} & (
   | SinglePropertyDatabasePropertyRelationConfigResponse
   | DualPropertyDatabasePropertyRelationConfigResponse
+)
 
 export type RelationDatabasePropertyConfigResponse = {
   type: "relation"
   relation: DatabasePropertyRelationConfigResponse
-  id: string
 }
 
 export type RollupDatabasePropertyConfigResponse = {
@@ -608,92 +601,144 @@ export type RollupDatabasePropertyConfigResponse = {
     relation_property_id: string
     function: RollupFunction
   }
-  id: string
 }
 
 export type UniqueIdDatabasePropertyConfigResponse = {
   type: "unique_id"
   unique_id: { prefix: string | null }
-  id: string
 }
 
 export type TitleDatabasePropertyConfigResponse = {
   type: "title"
-  title: TextRichTextItemResponse[]
-  id: string
+  title: EmptyObject
 }
 
 export type RichTextDatabasePropertyConfigResponse = {
   type: "rich_text"
-  rich_text: TextRichTextItemResponse[]
-  id: string
+  rich_text: EmptyObject
 }
 
 export type UrlDatabasePropertyConfigResponse = {
   type: "url"
-  url: string | null
-  id: string
+  url: EmptyObject
 }
 
 export type PeopleDatabasePropertyConfigResponse = {
   type: "people"
   people: EmptyObject
-  id: string
 }
 
 export type FilesDatabasePropertyConfigResponse = {
   type: "files"
   files: EmptyObject
-  id: string
 }
 
 export type EmailDatabasePropertyConfigResponse = {
   type: "email"
-  email: string | null
-  id: string
+  email: EmptyObject
 }
 
 export type PhoneNumberDatabasePropertyConfigResponse = {
   type: "phone_number"
-  phone_number: number | null
-  id: string
+  phone_number: EmptyObject
 }
 
 export type DateDatabasePropertyConfigResponse = {
   type: "date"
-  date: DateResponse | null
-  id: string
+  date: EmptyObject
 }
 
 export type CheckboxDatabasePropertyConfigResponse = {
   type: "checkbox"
-  checkbox: boolean
-  id: string
+  checkbox: EmptyObject
 }
 
 export type CreatedByDatabasePropertyConfigResponse = {
   type: "created_by"
   created_by: EmptyObject
-  id: string
 }
 
 export type CreatedTimeDatabasePropertyConfigResponse = {
   type: "created_time"
   created_time: EmptyObject
-  id: string
 }
 
 export type LastEditedByDatabasePropertyConfigResponse = {
   type: "last_edited_by"
   last_edited_by: EmptyObject
-  id: string
 }
 
 export type LastEditedTimeDatabasePropertyConfigResponse = {
   type: "last_edited_time"
   last_edited_time: EmptyObject
-  id: string
 }
+
+export type ButtonDatabasePropertyConfigResponse = {
+  type: "button"
+  button: EmptyObject
+}
+
+export type VerificationDatabasePropertyConfigResponse = {
+  type: "verification"
+  verification: EmptyObject
+}
+
+// The value a database property holds on a page.
+export type DatabasePropertyValue = { id: string } & (
+  | SimpleOrArrayPropertyValueResponse
+  | { type: 'rollup', rollup: RollupPropertyValueResponse }
+)
+
+export type SimpleOrArrayPropertyValueResponse =
+  | { type: 'title', title: Array<RichTextItemResponse> }
+  | { type: 'rich_text', rich_text: Array<RichTextItemResponse> }
+  | { type: 'people', people: Array<PartialUserObjectResponse> }
+  | { type: 'relation', relation: Array<{ id: IdRequest }> }
+  | { type: 'number', number: number | null }
+  | { type: 'url', url: string | null }
+  | { type: 'select', select: SelectPropertyResponse | null }
+  | { type: 'multi_select', multi_select: Array<SelectPropertyResponse> }
+  | { type: 'status', status: StatusPropertyResponse | null }
+  | { type: 'date', date: DateResponse | null }
+  | { type: 'email', email: string | null }
+  | { type: 'phone_number', phone_number: string | null }
+  | { type: 'checkbox', checkbox: boolean }
+  | { type: 'files', files: Array<FileWithNameResponse> }
+  | { type: 'created_by', created_by: PartialUserObjectResponse }
+  | { type: 'created_time', created_time: string }
+  | { type: 'last_edited_by', last_edited_by: PartialUserObjectResponse }
+  | { type: 'last_edited_time', last_edited_time: string }
+  | { type: 'formula', formula: FormulaPropertyValueResponse }
+  | { type: 'button', button: EmptyObject }
+  | { type: 'unique_id', unique_id: { prefix: string | null, number: number | null } }
+  | { type: 'verification', verification: VerificationPropertyValueResponse | null }
+
+export type FileWithNameResponse = { name: StringRequest } & (
+  | { type: 'file', file: { url: string, expiry_time: string } }
+  | { type: 'external', external: { url: TextRequest } }
+)
+
+export type FormulaPropertyValueResponse =
+  | { type: 'string', string: string | null }
+  | { type: 'date', date: DateResponse | null }
+  | { type: 'number', number: number | null }
+  | { type: 'boolean', boolean: boolean | null }
+  | { type: 'unsupported', unsupported: EmptyObject }
+
+export type RollupPropertyValueResponse = { function: RollupFunction } & (
+  | { type: 'number', number: number | null }
+  | { type: 'date', date: DateResponse | null }
+  | { type: 'array', array: Array<SimpleOrArrayPropertyValueResponse> }
+  | { type: 'unsupported', unsupported: EmptyObject }
+)
+
+export type VerificationPropertyValueResponse =
+  | { state: 'unverified', date: null, verified_by: null }
+  | {
+    state: 'verified' | 'expired'
+    date: DateResponse | null
+    verified_by: PartialUserObjectResponse | null
+  }
 
 export type ImagePathWithSize = {
   path: string

--- a/src/exporter/validation.test.ts
+++ b/src/exporter/validation.test.ts
@@ -3,33 +3,35 @@ import * as assert from 'uvu/assert'
 import type { QueryProperties } from './validation.js'
 import { validateQuery, buildQueryValidationMessage } from './validation.js'
 
-const properties = {
-  Name: { id: 'title', name: 'Name', type: 'title', title: {} },
-  Published: { id: 'aBcD', name: 'Published', type: 'checkbox', checkbox: {} },
+const properties: QueryProperties = {
+  Name: { id: 'title', name: 'Name', description: null, type: 'title', title: {} },
+  Published: { id: 'aBcD', name: 'Published', description: null, type: 'checkbox', checkbox: {} },
   Tags: {
     id: 'eFgH',
     name: 'Tags',
+    description: null,
     type: 'multi_select',
     multi_select: {
       options: [
-        { id: '1', name: 'Blog', color: 'blue' },
-        { id: '2', name: 'Release', color: 'red' },
+        { id: '1', name: 'Blog', color: 'blue', description: null },
+        { id: '2', name: 'Release', color: 'red', description: null },
       ],
     },
   },
   Status: {
     id: 'iJkL',
     name: 'Status',
+    description: null,
     type: 'status',
     status: {
       options: [
-        { id: '1', name: 'Done', color: 'green' },
+        { id: '1', name: 'Done', color: 'green', description: null },
       ],
       groups: [],
     },
   },
-  Date: { id: 'mNoP', name: 'Date', type: 'date', date: {} },
-} as unknown as QueryProperties
+  Date: { id: 'mNoP', name: 'Date', description: null, type: 'date', date: {} },
+}
 
 test('validateQuery returns no error for a valid query', () => {
   const errors = validateQuery({
@@ -95,6 +97,15 @@ test('validateQuery accepts a property id instead of a property name', () => {
     filter: { property: 'eFgH', multi_select: { contains: 'Blog' } },
   })
   assert.equal(errors, [])
+})
+
+test('validateQuery reports the property name when the query uses a property id', () => {
+  const errors = validateQuery({
+    properties,
+    filter: { property: 'eFgH', multi_select: { contains: 'News' } },
+  })
+  assert.equal(errors.length, 1)
+  assert.ok(errors[0]?.includes('is not an option of the "Tags" property'))
 })
 
 test('validateQuery accepts a rich_text filter on a title property', () => {

--- a/src/exporter/validation.ts
+++ b/src/exporter/validation.ts
@@ -59,18 +59,19 @@ const findProperty = (properties: QueryProperties, nameOrId: string): DatabasePr
 
 /** Returns option names when the property has selectable options, otherwise undefined. */
 const optionNamesOf = (prop: DatabasePropertyConfigResponse): string[] | undefined => {
-  const config = (prop as unknown as Record<string, unknown>)[prop.type]
-  if (config === null || typeof config !== 'object') {
-    return undefined
+  switch (prop.type) {
+    case 'select':
+      return prop.select.options.map(o => o.name)
+    case 'multi_select':
+      return prop.multi_select.options.map(o => o.name)
+    case 'status':
+      return prop.status.options.map(o => o.name)
+    default:
+      return undefined
   }
-  const options = (config as Record<string, unknown>)['options']
-  if (!Array.isArray(options)) {
-    return undefined
-  }
-  return options.map(o => `${(o as { name?: string }).name}`)
 }
 
-const validateCondition = (prop: DatabasePropertyConfigResponse, name: string, condition: unknown, path: string, errors: string[]): void => {
+const validateCondition = (prop: DatabasePropertyConfigResponse, condition: unknown, path: string, errors: string[]): void => {
   const options = optionNamesOf(prop)
   if (options === undefined || condition === null || typeof condition !== 'object') {
     return
@@ -80,7 +81,7 @@ const validateCondition = (prop: DatabasePropertyConfigResponse, name: string, c
       continue
     }
     if (!options.includes(value)) {
-      errors.push(`${path}.${key}: "${value}" is not an option of the "${name}" property -- available options: ${quotedList(options)}`)
+      errors.push(`${path}.${key}: "${value}" is not an option of the "${prop.name}" property -- available options: ${quotedList(options)}`)
     }
   }
 }
@@ -128,17 +129,17 @@ const validateFilter = (properties: QueryProperties, filter: unknown, path: stri
 
   const conditionKeys = Object.keys(f).filter(k => k !== 'property')
   if (conditionKeys.length === 0) {
-    errors.push(`${path}: property "${name}" has no condition, "${prop.type}" is expected`)
+    errors.push(`${path}: property "${prop.name}" has no condition, "${prop.type}" is expected`)
     return
   }
 
   const allowedKeys = filterKeysByPropertyType[prop.type] ?? [prop.type]
   for (const key of conditionKeys) {
     if (!allowedKeys.includes(key)) {
-      errors.push(`${path}: property "${name}" is a "${prop.type}" property, but the filter uses "${key}" -- "${allowedKeys[0]}" is expected`)
+      errors.push(`${path}: property "${prop.name}" is a "${prop.type}" property, but the filter uses "${key}" -- "${allowedKeys[0]}" is expected`)
       continue
     }
-    validateCondition(prop, name, f[key], `${path}.${key}`, errors)
+    validateCondition(prop, f[key], `${path}.${key}`, errors)
   }
 }
 

--- a/src/ui/components/Gallery/GalleryCard/GalleryHandler.tsx
+++ b/src/ui/components/Gallery/GalleryCard/GalleryHandler.tsx
@@ -1,3 +1,4 @@
+import { formulaNumber } from '../../lib.js'
 import GalleryCheckboxField from '../GalleryCheckboxField/GalleryCheckboxField.js'
 import GalleryDateField from '../GalleryDateField/GalleryDateField.js'
 import GalleryFormulaField from '../GalleryFormulaField/GalleryFormulaField.js'
@@ -33,7 +34,7 @@ const GalleryHandler = ({ property, options }: GalleryHandlerProps) => {
     case 'number':
       return <GalleryNumberField number={property.number} options={options} />
     case 'formula':
-      return <GalleryFormulaField number={property.formula.number} options={options} />
+      return <GalleryFormulaField number={formulaNumber(property.formula)} options={options} />
     default:
       console.log('unsupport database property:', property)
       return null

--- a/src/ui/components/Gallery/GallerySelectField/GallerySelectField.tsx
+++ b/src/ui/components/Gallery/GallerySelectField/GallerySelectField.tsx
@@ -3,6 +3,9 @@ import LinkedTagIfLinked from './LinkedTag.js'
 import './GallerySelectField.css'
 
 const GalleryMultiSelectField = ({ select, options }: GallerySelectFieldProps) => {
+  if (!select) {
+    return null
+  }
   const { name, color } = select
   const { pathname, link, query } = options || {}
   return (

--- a/src/ui/components/Gallery/GallerySelectField/GallerySelectField.types.ts
+++ b/src/ui/components/Gallery/GallerySelectField/GallerySelectField.types.ts
@@ -2,6 +2,6 @@ import type { SelectPropertyResponse } from '../../../../exporter/index.js'
 import type { GalleryPropertyOptions } from '../GalleryCard/GalleryHandler.types'
 
 export interface GallerySelectFieldProps {
-  select: SelectPropertyResponse
+  select: SelectPropertyResponse | null
   options?: GalleryPropertyOptions
 }

--- a/src/ui/components/List/ListHandler.tsx
+++ b/src/ui/components/List/ListHandler.tsx
@@ -1,3 +1,4 @@
+import { formulaNumber } from '../lib.js'
 import ListCheckboxField from './ListCheckboxField/ListCheckboxField.js'
 import ListDateField from './ListDateField/ListDateField.js'
 import ListFormulaField from './ListFormulaField/ListFormulaField.js'
@@ -33,7 +34,7 @@ const ListHandler = ({ property, options }: ListHandlerProps) => {
     case 'select':
       return <ListSelectField select={property.select} options={options} />
     case 'formula':
-      return <ListFormulaField number={property.formula.number} options={options} />
+      return <ListFormulaField number={formulaNumber(property.formula)} options={options} />
     default:
       console.log('unsupport database property:', property)
       return null

--- a/src/ui/components/List/ListSelectField/ListSelectField.types.ts
+++ b/src/ui/components/List/ListSelectField/ListSelectField.types.ts
@@ -2,6 +2,6 @@ import type { SelectPropertyResponse } from '../../../../exporter/index.js'
 import type { ListPropertyOptions } from '../ListHandler.types'
 
 export interface ListSelectFieldProps {
-  select: SelectPropertyResponse
+  select: SelectPropertyResponse | null
   options?: ListPropertyOptions
 }

--- a/src/ui/components/Table/TableHandler.tsx
+++ b/src/ui/components/Table/TableHandler.tsx
@@ -1,3 +1,4 @@
+import { formulaNumber } from '../lib.js'
 import TableCheckboxField from './TableCheckboxField/TableCheckboxField.js'
 import TableDateField from './TableDateField/TableDateField.js'
 import TableFormulaField from './TableFormulaField/TableFormulaField.js'
@@ -33,7 +34,7 @@ const TableHandler = ({ property, options }: TableHandlerProps) => {
     case 'select':
       return <TableSelectField select={property.select} options={options} />
     case 'formula':
-      return <TableFormulaField number={property.formula.number} options={options} />
+      return <TableFormulaField number={formulaNumber(property.formula)} options={options} />
     default:
       console.log('unsupport database property:', property)
       return null

--- a/src/ui/components/Table/TableSelectField/TableSelectField.types.ts
+++ b/src/ui/components/Table/TableSelectField/TableSelectField.types.ts
@@ -2,6 +2,6 @@ import type { SelectPropertyResponse } from '../../../../exporter/index.js'
 import type { TablePropertyOptions } from '../TableHandler.types'
 
 export interface TableSelectFieldProps {
-  select: SelectPropertyResponse
+  select: SelectPropertyResponse | null
   options?: TablePropertyOptions
 }

--- a/src/ui/components/lib.ts
+++ b/src/ui/components/lib.ts
@@ -1,6 +1,6 @@
 import type { ParsedUrlQueryInput } from 'node:querystring'
 import { useState } from 'react'
-import type { GetPageResponse, ListBlockChildrenResponseEx } from '../../exporter/index.js'
+import type { FormulaPropertyValueResponse, GetPageResponse, ListBlockChildrenResponseEx } from '../../exporter/index.js'
 
 export function queryToString(q: ParsedUrlQueryInput | undefined) {
   if (q === undefined) {
@@ -97,6 +97,12 @@ export function getDatetimeFormat(lang?: string) {
 
 export function richTextKey(plainText: string | undefined, index: number): string {
   return `${plainText || 'empty'}-${index}`
+}
+
+// A formula property holds a string, a date or a boolean as well as a number,
+// and the formula fields only render a number.
+export function formulaNumber(formula: FormulaPropertyValueResponse): number | null {
+  return formula.type === 'number' ? formula.number : null
 }
 
 export function splitUrl(url: string) {


### PR DESCRIPTION
## Problem

The hand-written `*DatabasePropertyConfigResponse` types in `src/exporter/types.ts` matched neither shape the notion api returns:

| type | declared | actually returned |
| --- | --- | --- |
| `select` | `SelectPropertyResponse` | `{ options: [...] }` |
| `multi_select` | `SelectPropertyResponse[]` | `{ options: [...] }` |
| `number` | `number \| null` | `{ format }` |
| `formula` | `NumberDatabasePropertyConfigResponse` | `{ expression }` |
| `title` / `rich_text` / `url` / `email` / `date` / `checkbox` | the page value | `{}` |
| every property | — | also has `name` and `description` |

`FetchDatabase` assigns the data source properties to `GetDatabaseResponseEx.properties`, which is typed with them, so the types lied about real data. `validation.ts` worked around it:

```ts
const config = (prop as unknown as Record<string, unknown>)[prop.type]
```

and its test fixture needed `as unknown as QueryProperties` to be written at all.

## Cause

Two different objects shared one type. A database property has **a schema**, returned in the `properties` of a data source, and **a value**, returned in the `properties` of a page — a select property is `{ options: [...] }` in the former and a single option in the latter. The declarations were mostly the value shape, while the schema was what they were used for.

## Changes

**Split the two, and make each match the api**

- `DatabasePropertyConfigResponse` is the schema. `DatabasePropertyConfigResponseCommon` carries `id` / `name` / `description`, the per-type members carry the real config, and `button` / `verification` are added.
- `DatabasePropertyValue` is the value a property holds on a page. `DatabaseProperty` aliases it, since that is what the ui components have always passed to it, and `DBProperties` — a second, diverging copy of the same union — now refers to it.

Both were verified by assigning a real query response of the current api (`website/.cache`, schema and page values) to them under `strict`, with excess property checking on.

**Drop the casts in `validation.ts`**

`optionNamesOf` narrows on `prop.type` instead of indexing an `unknown` record, and the test fixture is a plain `QueryProperties`.

**Report the property name, not the id**

A query may refer to a property by id, which the messages echoed back:

```
filter.multi_select.contains: "News" is not an option of the "eFgH" property
```

`name` is now on the schema type, so they resolve it:

```
filter.multi_select.contains: "News" is not an option of the "Tags" property
```

**Two latent ui bugs the accurate types surfaced**

- `property.formula.number` is `undefined` unless the formula returns a number — a string, date or boolean formula rendered nothing. `formulaNumber()` in `lib.ts` narrows it, and the three handlers use it.
- `GallerySelectField` destructured `select`, which is `null` when a page has no option set. It now returns `null` like the table and list fields already did.

## Test

`npm run build` and `npm test` (154 tests, 1 new) pass. No new lint warnings.

## Version

Bumped to `v3.6.0`. The exported types change shape, so this is not a patch: `DatabasePropertyConfigResponse` now describes the data source schema it was always used for, and `DatabaseProperty` points at `DatabasePropertyValue` instead. Code that was already passing page properties to `DatabaseProperty` — as the ui components do — keeps working.
